### PR TITLE
Add Vault EngineType

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,11 +1,15 @@
 package pentagon
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/vimeo/pentagon/vault"
+)
 
 func TestSetDefaults(t *testing.T) {
 	c := &Config{
 		Vault: VaultConfig{
-			AuthType: VaultAuthTypeToken,
+			AuthType: vault.AuthTypeToken,
 		},
 	}
 
@@ -16,6 +20,16 @@ func TestSetDefaults(t *testing.T) {
 
 	if c.Namespace != DefaultNamespace {
 		t.Fatalf("namespace should be %s, is %s", DefaultNamespace, c.Namespace)
+	}
+
+	if c.Vault.DefaultEngineType != vault.EngineTypeKeyValueV1 {
+		t.Fatalf("unexpected default engine type: %s", c.Vault.DefaultEngineType)
+	}
+
+	for _, m := range c.Mappings {
+		if m.VaultEngineType == "" {
+			t.Fatalf("empty vault engine type for mapping: %+v", m)
+		}
 	}
 }
 
@@ -56,5 +70,4 @@ func TestValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("configuration should have been valid: %s", err)
 	}
-
 }

--- a/pentagon/main.go
+++ b/pentagon/main.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/vimeo/pentagon"
+	"github.com/vimeo/pentagon/vault"
 )
 
 func main() {
@@ -104,9 +105,9 @@ func getVaultClient(vaultConfig pentagon.VaultConfig) (*api.Client, error) {
 	}
 
 	switch vaultConfig.AuthType {
-	case pentagon.VaultAuthTypeToken:
+	case vault.AuthTypeToken:
 		client.SetToken(vaultConfig.Token)
-	case pentagon.VaultAuthTypeGCPDefault:
+	case vault.AuthTypeGCPDefault:
 		// default to using configured Role
 		role := vaultConfig.Role
 

--- a/pentagon/main_test.go
+++ b/pentagon/main_test.go
@@ -26,7 +26,7 @@ const k8sNamespace = "default"
 const configMapName = "pentagon-config"
 
 type integrationTests struct {
-	vaultInstance vault
+	vaultInstance vaultHelper
 	pj            pentagonJob
 	client        *kubernetes.Clientset
 }
@@ -85,7 +85,7 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("unable to delete existing jobs: %s", err)
 	}
 
-	vaultInstance := vault{
+	vaultInstance := vaultHelper{
 		client:     clientset,
 		restConfig: restConfig,
 		namespace:  k8sNamespace,

--- a/pentagon/vault_test.go
+++ b/pentagon/vault_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // helper struct for working with vault instance in k8s
-type vault struct {
+type vaultHelper struct {
 	client     *kubernetes.Clientset
 	restConfig *restclient.Config // this was used to create the client above!
 	namespace  string
@@ -24,7 +24,7 @@ type vault struct {
 }
 
 // sets a secret by exec'ing into the pod and running the command line client.
-func (v *vault) setSecret(path string, values map[string]string) error {
+func (v *vaultHelper) setSecret(path string, values map[string]string) error {
 	valuePairs := []string{}
 	for k, v := range values {
 		valuePairs = append(valuePairs, fmt.Sprintf("%s=%s", k, v))
@@ -69,12 +69,12 @@ func (v *vault) setSecret(path string, values map[string]string) error {
 }
 
 // returns the url to the pod.
-func (v *vault) url() string {
+func (v *vaultHelper) url() string {
 	return fmt.Sprintf("http://%s:%d", v.pod.Status.PodIP, vaultPort)
 }
 
 // create a vault instance in k8s.
-func (v *vault) create(wait time.Duration) error {
+func (v *vaultHelper) create(wait time.Duration) error {
 	// see if it exists first
 	pods := v.client.CoreV1().Pods(v.namespace)
 	p, err := pods.Get("vault", metav1.GetOptions{})

--- a/reflector_test.go
+++ b/reflector_test.go
@@ -11,13 +11,265 @@ import (
 	"github.com/vimeo/pentagon/vault"
 )
 
-func TestReflectorSimple(t *testing.T) {
+func allEngineTest(t *testing.T, subTest func(testing.TB, vault.EngineType)) {
+	types := vault.AllEngineTypes
+	for _, engineType := range types {
+		et := engineType
+		t.Run(string(engineType), func(innerT *testing.T) {
+			innerT.Parallel()
+			subTest(innerT, et)
+		})
+	}
+}
+
+func TestRefactorSimple(t *testing.T) {
+	allEngineTest(t, func(t testing.TB, engineType vault.EngineType) {
+		k8sClient := k8sfake.NewSimpleClientset()
+		vaultClient := vault.NewMock(map[string]vault.EngineType{
+			"secrets": engineType,
+		})
+
+		data := map[string]interface{}{
+			"foo": "bar",
+			"bar": "baz",
+		}
+		vaultClient.Write("secrets/data/foo", data)
+
+		r := NewReflector(
+			vaultClient,
+			k8sClient, DefaultNamespace,
+			DefaultLabelValue,
+		)
+
+		err := r.Reflect([]Mapping{
+			{
+				VaultPath:       "secrets/data/foo",
+				SecretName:      "foo",
+				VaultEngineType: engineType,
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work: %s", err)
+		}
+
+		// now get the secret out of k8s
+		secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+		secret, err := secrets.Get("foo", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("secret should be there: %s", err)
+		}
+
+		if secret.Labels[LabelKey] != DefaultLabelValue {
+			t.Fatalf(
+				"secret pentagon label should be %s is %s",
+				DefaultLabelValue,
+				secret.Labels[LabelKey],
+			)
+		}
+
+		if string(secret.Data["foo"]) != "bar" {
+			t.Fatalf("foo does not equal bar: %s", string(secret.Data["foo"]))
+		}
+
+		if string(secret.Data["bar"]) != "baz" {
+			t.Fatalf("bar does not equal baz: %s", string(secret.Data["bar"]))
+		}
+	})
+}
+
+func TestReflectorNoReconcile(t *testing.T) {
+	allEngineTest(t, func(t testing.TB, engineType vault.EngineType) {
+		k8sClient := k8sfake.NewSimpleClientset()
+		vaultClient := vault.NewMock(map[string]vault.EngineType{
+			"secrets": engineType,
+		})
+
+		data := map[string]interface{}{
+			"foo": "bar",
+			"bar": "baz",
+		}
+
+		// write two secrets
+		vaultClient.Write("secrets/data/foo1", data)
+		vaultClient.Write("secrets/data/foo2", data)
+
+		r := NewReflector(
+			vaultClient,
+			k8sClient,
+			DefaultNamespace,
+			DefaultLabelValue,
+		)
+
+		// reflect both secrets
+		err := r.Reflect([]Mapping{
+			{
+				VaultPath:       "secrets/data/foo1",
+				SecretName:      "foo1",
+				VaultEngineType: engineType,
+			},
+			{
+				VaultPath:       "secrets/data/foo2",
+				SecretName:      "foo2",
+				VaultEngineType: engineType,
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work: %s", err)
+		}
+
+		// now get the secrets out of k8s
+		secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+		_, err = secrets.Get("foo1", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo1 should be there: %s", err)
+		}
+
+		_, err = secrets.Get("foo2", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo2 should be there: %s", err)
+		}
+
+		// reflect again, this time without foo2 -- it should still be there
+		// and not get reconciled because we're using the default label value.
+		err = r.Reflect([]Mapping{
+			{
+				VaultPath:       "secrets/data/foo1",
+				SecretName:      "foo1",
+				VaultEngineType: engineType,
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work the second time: %s", err)
+		}
+
+		_, err = secrets.Get("foo1", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo1 should still be there: %s", err)
+		}
+
+		_, err = secrets.Get("foo2", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo2 should still be there: %s", err)
+		}
+	})
+}
+
+func TestReflectorWithReconcile(t *testing.T) {
+	allEngineTest(t, func(t testing.TB, engineType vault.EngineType) {
+		k8sClient := k8sfake.NewSimpleClientset()
+		vaultClient := vault.NewMock(map[string]vault.EngineType{
+			"secrets": engineType,
+		})
+
+		data := map[string]interface{}{
+			"foo": "bar",
+			"bar": "baz",
+		}
+
+		// write two secrets
+		vaultClient.Write("secrets/data/foo1", data)
+		vaultClient.Write("secrets/data/foo2", data)
+
+		secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+		// make another secret with a different label value so we confirm that
+		// it's still there after reconciliation
+		otherLabel := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "other-reflect",
+				Labels: map[string]string{
+					LabelKey: "other",
+				},
+			},
+			Data: map[string][]byte{
+				"something": []byte("else"),
+			},
+		}
+		_, err := secrets.Create(otherLabel)
+		if err != nil {
+			t.Fatalf("unable to create other-reflect secret: %s", err)
+		}
+
+		r := NewReflector(vaultClient, k8sClient, DefaultNamespace, "test")
+
+		err = r.Reflect([]Mapping{
+			{
+				VaultPath:       "secrets/data/foo1",
+				SecretName:      "foo1",
+				VaultEngineType: engineType,
+			},
+			{
+				VaultPath:       "secrets/data/foo2",
+				SecretName:      "foo2",
+				VaultEngineType: engineType,
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work: %s", err)
+		}
+
+		s, err := secrets.Get("foo1", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo1 should be there: %s", err)
+		}
+
+		if s.Labels[LabelKey] != "test" {
+			t.Fatalf(
+				"foo1 pentagon label should have been 'test': %s",
+				s.Labels[LabelKey],
+			)
+		}
+
+		_, err = secrets.Get("foo2", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo2 should be there: %s", err)
+		}
+
+		// reflect again, this time without foo2 -- it should get reconciled
+		// because we're using a non-default label value.
+		err = r.Reflect([]Mapping{
+			{
+				VaultPath:       "secrets/data/foo1",
+				SecretName:      "foo1",
+				VaultEngineType: engineType,
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work the second time: %s", err)
+		}
+
+		// foo1 should still be there because it's still in the mapping
+		_, err = secrets.Get("foo1", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("foo1 should still be there: %s", err)
+		}
+
+		// foo2 should have been deleted because it wasn't in the mapping
+		// and we're using a non-default label
+		_, err = secrets.Get("foo2", metav1.GetOptions{})
+		if !errors.IsNotFound(err) {
+			t.Fatalf("foo2 should NOT still be there: %s", err)
+		}
+
+		// the one with the different label value should still be there
+		_, err = secrets.Get("other-reflect", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("other-reflect should still be there: %s", err)
+		}
+	})
+}
+
+func TestUnsupportedEngineType(t *testing.T) {
 	k8sClient := k8sfake.NewSimpleClientset()
-	vaultClient := vault.NewMock()
+
+	vaultClient := vault.NewMock(map[string]vault.EngineType{
+		"secrets": vault.EngineTypeKeyValueV2,
+	})
 
 	data := map[string]interface{}{
 		"foo": "bar",
-		"bar": "baz",
 	}
 	vaultClient.Write("secrets/data/foo", data)
 
@@ -29,204 +281,12 @@ func TestReflectorSimple(t *testing.T) {
 
 	err := r.Reflect([]Mapping{
 		{
-			VaultPath:  "secrets/data/foo",
-			SecretName: "foo",
+			VaultPath:       "secrets/data/foo",
+			SecretName:      "foo",
+			VaultEngineType: vault.EngineType("unsupported"),
 		},
 	})
-	if err != nil {
-		t.Fatalf("reflect didn't work: %s", err)
-	}
-
-	// now get the secret out of k8s
-	secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
-
-	secret, err := secrets.Get("foo", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("secret should be there: %s", err)
-	}
-
-	if secret.Labels[LabelKey] != DefaultLabelValue {
-		t.Fatalf(
-			"secret pentagon label should be %s is %s",
-			DefaultLabelValue,
-			secret.Labels[LabelKey],
-		)
-	}
-
-	if string(secret.Data["foo"]) != "bar" {
-		t.Fatalf("foo does not equal bar: %s", string(secret.Data["foo"]))
-	}
-
-	if string(secret.Data["bar"]) != "baz" {
-		t.Fatalf("bar does not equal baz: %s", string(secret.Data["bar"]))
-	}
-}
-
-func TestReflectorNoReconcile(t *testing.T) {
-	k8sClient := k8sfake.NewSimpleClientset()
-	vaultClient := vault.NewMock()
-
-	data := map[string]interface{}{
-		"foo": "bar",
-		"bar": "baz",
-	}
-
-	// write two secrets
-	vaultClient.Write("secrets/data/foo1", data)
-	vaultClient.Write("secrets/data/foo2", data)
-
-	r := NewReflector(
-		vaultClient,
-		k8sClient,
-		DefaultNamespace,
-		DefaultLabelValue,
-	)
-
-	// reflect both secrets
-	err := r.Reflect([]Mapping{
-		{
-			VaultPath:  "secrets/data/foo1",
-			SecretName: "foo1",
-		},
-		{
-			VaultPath:  "secrets/data/foo2",
-			SecretName: "foo2",
-		},
-	})
-	if err != nil {
-		t.Fatalf("reflect didn't work: %s", err)
-	}
-
-	// now get the secrets out of k8s
-	secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
-
-	_, err = secrets.Get("foo1", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo1 should be there: %s", err)
-	}
-
-	_, err = secrets.Get("foo2", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo2 should be there: %s", err)
-	}
-
-	// reflect again, this time without foo2 -- it should still be there
-	// and not get reconciled because we're using the default label value.
-	err = r.Reflect([]Mapping{
-		{
-			VaultPath:  "secrets/data/foo1",
-			SecretName: "foo1",
-		},
-	})
-	if err != nil {
-		t.Fatalf("reflect didn't work the second time: %s", err)
-	}
-
-	_, err = secrets.Get("foo1", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo1 should still be there: %s", err)
-	}
-
-	_, err = secrets.Get("foo2", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo2 should still be there: %s", err)
-	}
-}
-
-func TestReflectorWithReconcile(t *testing.T) {
-	k8sClient := k8sfake.NewSimpleClientset()
-	vaultClient := vault.NewMock()
-
-	data := map[string]interface{}{
-		"foo": "bar",
-		"bar": "baz",
-	}
-
-	// write two secrets
-	vaultClient.Write("secrets/data/foo1", data)
-	vaultClient.Write("secrets/data/foo2", data)
-
-	secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
-
-	// make another secret with a different label value so we confirm that
-	// it's still there after reconciliation
-	otherLabel := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "other-reflect",
-			Labels: map[string]string{
-				LabelKey: "other",
-			},
-		},
-		Data: map[string][]byte{
-			"something": []byte("else"),
-		},
-	}
-	_, err := secrets.Create(otherLabel)
-	if err != nil {
-		t.Fatalf("unable to create other-reflect secret: %s", err)
-	}
-
-	r := NewReflector(vaultClient, k8sClient, DefaultNamespace, "test")
-
-	err = r.Reflect([]Mapping{
-		{
-			VaultPath:  "secrets/data/foo1",
-			SecretName: "foo1",
-		},
-		{
-			VaultPath:  "secrets/data/foo2",
-			SecretName: "foo2",
-		},
-	})
-	if err != nil {
-		t.Fatalf("reflect didn't work: %s", err)
-	}
-
-	s, err := secrets.Get("foo1", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo1 should be there: %s", err)
-	}
-
-	if s.Labels[LabelKey] != "test" {
-		t.Fatalf(
-			"foo1 pentagon label should have been 'test': %s",
-			s.Labels[LabelKey],
-		)
-	}
-
-	_, err = secrets.Get("foo2", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo2 should be there: %s", err)
-	}
-
-	// reflect again, this time without foo2 -- it should get reconciled
-	// because we're using a non-default label value.
-	err = r.Reflect([]Mapping{
-		{
-			VaultPath:  "secrets/data/foo1",
-			SecretName: "foo1",
-		},
-	})
-	if err != nil {
-		t.Fatalf("reflect didn't work the second time: %s", err)
-	}
-
-	// foo1 should still be there because it's still in the mapping
-	_, err = secrets.Get("foo1", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("foo1 should still be there: %s", err)
-	}
-
-	// foo2 should have been deleted because it wasn't in the mapping
-	// and we're using a non-default label
-	_, err = secrets.Get("foo2", metav1.GetOptions{})
-	if !errors.IsNotFound(err) {
-		t.Fatalf("foo2 should NOT still be there: %s", err)
-	}
-
-	// the one with the different label value should still be there
-	_, err = secrets.Get("other-reflect", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("other-reflect should still be there: %s", err)
+	if err == nil {
+		t.Fatal("expected error from unsupported engine type")
 	}
 }

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -1,50 +1,76 @@
 package vault
 
-import "testing"
+import (
+	"testing"
 
-func TestWrite(t *testing.T) {
-	m := NewMock()
-	secret, err := m.Write("test", map[string]interface{}{
-		"blah": "blah",
-	})
+	"github.com/hashicorp/vault/api"
+)
 
-	if err != nil {
-		t.Fatalf("write errored: %s", err)
+func TestRoundtrip(t *testing.T) {
+	for testName, itbl := range map[string]struct {
+		key   string
+		data  map[string]interface{}
+		check func(testing.TB, *api.Secret, error)
+	}{
+		"simple-kv-1": {
+			key: "kv1/test",
+			data: map[string]interface{}{
+				"blah": "blah",
+			},
+			check: func(t testing.TB, s *api.Secret, err error) {
+				if err != nil {
+					t.Fatalf("errored: %s", err)
+				}
+
+				if s.Data["blah"] != "blah" {
+					t.Fatal("data was not equal!")
+				}
+			},
+		},
+		"simple-kv-2": {
+			key: "kv2/test",
+			data: map[string]interface{}{
+				"blah": "blah",
+			},
+			check: func(t testing.TB, s *api.Secret, err error) {
+				if err != nil {
+					t.Fatalf("errored: %s", err)
+				}
+
+				if w, ok := s.Data["data"].(map[string]interface{}); ok {
+					if w["blah"] != "blah" {
+						t.Fatal("data was not equal!")
+					}
+				} else {
+					t.Fatal("extra wrapping didn't exist")
+				}
+			},
+		},
+	} {
+		tbl := itbl
+		t.Run(testName, func(t *testing.T) {
+			mounting := map[string]EngineType{
+				"kv1": EngineTypeKeyValueV1,
+				"kv2": EngineTypeKeyValueV2,
+			}
+			m := NewMock(mounting)
+			secret, err := m.Write(tbl.key, tbl.data)
+			tbl.check(t, secret, err)
+
+			// now read the same secret out
+			secret, err = m.Read(tbl.key)
+			tbl.check(t, secret, err)
+		})
 	}
 
-	if secret.Data["blah"] != "blah" {
-		t.Fatal("data was not equal!")
-	}
-}
-
-func TestRead(t *testing.T) {
-	m := NewMock()
-	_, err := m.Write("test", map[string]interface{}{
-		"blah": "blah",
-	})
-
-	if err != nil {
-		t.Fatalf("write errored: %s", err)
-	}
-
-	secret, err := m.Read("test")
-	if err != nil {
-		t.Fatalf("read errored: %s", err)
-	}
-
-	if secret == nil {
-		t.Fatal("secret was nil")
-	}
-
-	if secret.Data["blah"] != "blah" {
-		t.Fatal("data was not equal!")
-	}
 }
 
 func TestReadNotFound(t *testing.T) {
-	m := NewMock()
+	m := NewMock(map[string]EngineType{
+		"secret": EngineTypeKeyValueV1,
+	})
 
-	secret, err := m.Read("not-there")
+	secret, err := m.Read("secret/not-there")
 	if secret != nil {
 		t.Fatal("secret should be nil")
 	}


### PR DESCRIPTION
Apparently, Vault secrets engines have slightly different API responses
which need to be parsed differently.  In particular, kv-v2 (version 2 of
the Key/Value secrets engine) has an extra layer of data wrapping so
responses look like this:

```json
{
  "request_id": "78b921ae-79a8-d7e3-da16-336b634fff22",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "data": {
      "foo": "world"
    },
    "metadata": {
      "created_time": "2019-10-01T19:36:25.285387Z",
      "deletion_time": "",
      "destroyed": false,
      "version": 1
    }
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
```

Data data data data data.

kv version1 secrets look like this:
```json
{
  "request_id": "12a0c057-f475-4bbd-6305-e4c07e66805c",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 2764800,
  "data": {
    "foo": "world"
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
```

Since we don't know which version Vault will have mounted where we have
to specify an engine type per mapping.  This is inconvenient, so I've
also added a `defaultEngineType` which will be used when one isn't
defined at the mapping level.

Also, all tests have been updated to run with all engine types to catch
any issues.