### PR TITLE
Fix EngineType Defaulting

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,9 +48,9 @@ func (c *Config) SetDefaults() {
 
 	// set all the underlying mapping engine types to their default
 	// if unspecified
-	for _, m := range c.Mappings {
+	for i, m := range c.Mappings {
 		if m.VaultEngineType == "" {
-			m.VaultEngineType = c.Vault.DefaultEngineType
+			c.Mappings[i].VaultEngineType = c.Vault.DefaultEngineType
 		}
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,12 @@ func TestSetDefaults(t *testing.T) {
 		Vault: VaultConfig{
 			AuthType: vault.AuthTypeToken,
 		},
+		Mappings: []Mapping{
+			{
+				VaultPath:  "vaultPath",
+				SecretName: "theSecret",
+			},
+		},
 	}
 
 	c.SetDefaults()

--- a/pentagon/main_test.go
+++ b/pentagon/main_test.go
@@ -205,7 +205,7 @@ func (it *integrationTests) testReconcile(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"blah": []byte{1, 2, 3},
+			"blah": {1, 2, 3},
 		},
 	}
 
@@ -379,7 +379,7 @@ func initRBAC(client *kubernetes.Clientset) error {
 			Namespace: k8sNamespace,
 		},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1.PolicyRule{
+			{
 				Verbs:     []string{"get", "list", "create", "update", "delete"},
 				Resources: []string{"secrets"},
 				APIGroups: []string{rbacv1.APIGroupAll},
@@ -393,7 +393,7 @@ func initRBAC(client *kubernetes.Clientset) error {
 			Namespace: k8sNamespace,
 		},
 		Subjects: []rbacv1.Subject{
-			rbacv1.Subject{
+			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      "default",
 				Namespace: k8sNamespace,

--- a/pentagon/pentagon_test.go
+++ b/pentagon/pentagon_test.go
@@ -76,11 +76,11 @@ func (p *pentagonJob) run(wait time.Duration) error {
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Name:  "pentagon",
 							Image: "pentagon:0.0.0",
 							VolumeMounts: []v1.VolumeMount{
-								v1.VolumeMount{
+								{
 									MountPath: "/pentagon-config",
 									Name:      "config-map-volume",
 								},
@@ -90,7 +90,7 @@ func (p *pentagonJob) run(wait time.Duration) error {
 					},
 					RestartPolicy: v1.RestartPolicyNever,
 					Volumes: []v1.Volume{
-						v1.Volume{
+						{
 							Name: "config-map-volume",
 							VolumeSource: v1.VolumeSource{
 								ConfigMap: &v1.ConfigMapVolumeSource{

--- a/pentagon/vault_test.go
+++ b/pentagon/vault_test.go
@@ -89,14 +89,14 @@ func (v *vaultHelper) create(wait time.Duration) error {
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:  "vault",
 					Image: "vault:1.1.1",
 					Env: []v1.EnvVar{
-						v1.EnvVar{Name: "VAULT_DEV_ROOT_TOKEN_ID", Value: testRootToken},
-						v1.EnvVar{Name: "VAULT_TOKEN", Value: testRootToken}, // so the client will work too
-						v1.EnvVar{Name: "VAULT_DEV_LISTEN_ADDRESS", Value: fmt.Sprintf("0.0.0.0:%d", vaultPort)},
-						v1.EnvVar{Name: "VAULT_ADDR", Value: fmt.Sprintf("http://127.0.0.1:%d", vaultPort)},
+						{Name: "VAULT_DEV_ROOT_TOKEN_ID", Value: testRootToken},
+						{Name: "VAULT_TOKEN", Value: testRootToken}, // so the client will work too
+						{Name: "VAULT_DEV_LISTEN_ADDRESS", Value: fmt.Sprintf("0.0.0.0:%d", vaultPort)},
+						{Name: "VAULT_ADDR", Value: fmt.Sprintf("http://127.0.0.1:%d", vaultPort)},
 					},
 					ReadinessProbe: &v1.Probe{
 						Handler: v1.Handler{


### PR DESCRIPTION
This fixes a bug that would cause the EngineType not to be defaulted as expected.

Also, simplify struct literals using `gofmt -s`.