### PR TITLE
Support Google Secret Manager Encoding

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,12 @@ const (
 
 	// GSMSourceType indicates a mapping sourced from Google Secrets Manager.
 	GSMSourceType = "gsm"
+
+	// GSM encoded as just raw bytes (default)
+	GSMEncodingTypeDefault = "default"
+
+	// GSM encoded as json
+	GSMEncodingTypeJSON = "json"
 )
 
 // Config describes the configuration for Pentagon.
@@ -71,9 +77,14 @@ func (c *Config) SetDefaults() {
 			c.Mappings[i].Path = m.VaultPath
 		}
 
+		if m.GSMEncodingType == "" {
+			c.Mappings[i].GSMEncodingType = GSMEncodingTypeDefault
+		}
+
 		if m.VaultEngineType == "" {
 			c.Mappings[i].VaultEngineType = c.Vault.DefaultEngineType
 		}
+
 		if m.SecretType == "" {
 			c.Mappings[i].SecretType = corev1.SecretTypeOpaque
 		}
@@ -158,4 +169,8 @@ type Mapping struct {
 	// Vault secret.  This specifically overrides the DefaultEngineType
 	// specified in VaultConfig.
 	VaultEngineType vault.EngineType `yaml:"vaultEngineType"`
+
+	// GSMEncodingType enables the parsing of JSON secrets with more than one key-value pair when set
+	// to 'json'. For the default behavior, simple values, set to 'string'.
+	GSMEncodingType string `yaml:"gsmEncodingType"`
 }

--- a/gsm/mock_gsm_test.go
+++ b/gsm/mock_gsm_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestMockGSM(t *testing.T) {
-	m := NewMockGSM()
+	m := NewMockGSM(map[string][]byte{
+		"projects/foo/locations/bar/secrets/baz/versions/3": []byte("foo_bar_baz_3"),
+		"projects/foo/secrets/bar/versions/latest":          []byte("foo_bar_latest"),
+	})
 	ctx := context.Background()
 
 	// Test regional secrets.

--- a/reflector_test.go
+++ b/reflector_test.go
@@ -24,7 +24,7 @@ func allEngineTest(t *testing.T, subTest func(testing.TB, vault.EngineType)) {
 	}
 }
 
-func TestRefactorSimple(t *testing.T) {
+func TestReflectorSimple(t *testing.T) {
 	allEngineTest(t, func(t testing.TB, engineType vault.EngineType) {
 		ctx := context.Background()
 
@@ -84,7 +84,7 @@ func TestRefactorSimple(t *testing.T) {
 	})
 }
 
-func TestRefactorGSM(t *testing.T) {
+func TestReflectorGSM(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := k8sfake.NewSimpleClientset()
 
@@ -131,7 +131,7 @@ func TestRefactorGSM(t *testing.T) {
 	}
 }
 
-func TestRefactorGSMJSON(t *testing.T) {
+func TestReflectorGSMJSON(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := k8sfake.NewSimpleClientset()
 


### PR DESCRIPTION
Google Secret Manager's API returns secrets always as a `[]byte`.
Kubernetes secrets can have additional depth with multiple key and value
pairs.  To support this naturally within Pentagon, introduce a
GSMEncodingType parameter that allows the user to parse the contents of
the secret as a JSON file into a `map[string]json.RawMessage`, preserving
the encoding of the inner secret's value.  Then map each of those keys
to individual "sub-secrets" in K8s.

Also, fix a few typos in the reflector test.