### PR TITLE
support additional kubernetes secret labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ mappings:
     secretName: k8s-secretname
     vaultEngineType: # optionally "kv" or "kv-v2" to override the defaultEngineType specified above
     secretType: Opaque # optionally - default "Opaque" e.g.: "kubernetes.io/tls"
+    additionalSecretLabels: # optionally add labels to the secret
+      environment: dev
+      team: core-services
   # mappings from google secrets manager paths to kubernetes secret names
   - sourceType: gsm
     path: projects/my-project/secrets/my-secret/versions/latest
@@ -33,10 +36,15 @@ mappings:
   - sourceType: gsm
     path: projects/my-project/secrets/my-other-secret
     secretName: defaults-to-latest-version
+    additionalSecretLabels:
+      environment: dev
+      team: core-services
 ```
 
 ### Labels and Reconciliation
 By default, Pentagon will add a [metadata label](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta) with the key `pentagon` and the value `default`.  At the least, this helps identify Pentagon as the creator and maintainer of the secret.
+
+You can also specify custom labels for each secret mapping using the `additionalSecretLabels` filed. These labels will be added to the Kubernetes secret alongside the required `pentagon` label. 
 
 If you set the `label` configuration parameter, you can control the value of the label, allowing multiple Pentagon instances to exist without stepping on each other.  Setting a non-default `label` also enables reconciliation which will cleanup any secrets that were created by Pentagon with a matching label, but are no longer present in the `mappings` configuration.  This provides a simple way to ensure that old secret data does not remain present in your system after its time has passed.
 

--- a/config.go
+++ b/config.go
@@ -191,4 +191,8 @@ type Mapping struct {
 	// use for this secret's value in cases where gsmEncodingType is *not* json.  If
 	// this is unset, the key name will default to the value of secretName.
 	GSMSecretKeyValue string `yaml:"gsmSecretKeyValue"`
+
+	// AdditionalSecretLabels allows you to specify the additional labels that will be
+	// added to the created Kubernetes secret.
+	AdditionalSecretLabels map[string]string `yaml:"additionalSecretLabels"`
 }

--- a/reflector_test.go
+++ b/reflector_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"maps"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,11 +69,10 @@ func TestReflectorSimple(t *testing.T) {
 			t.Fatalf("secret should be there: %s", err)
 		}
 
-		if secret.Labels[LabelKey] != DefaultLabelValue {
-			t.Fatalf(
-				"secret pentagon label should be %s is %s",
-				DefaultLabelValue,
-				secret.Labels[LabelKey],
+		// no additional labels provided. check for default
+		if !maps.Equal(secret.Labels, map[string]string{LabelKey: DefaultLabelValue}) {
+			t.Fatalf("labels do not match: got %v, want %v", secret.Labels,
+				map[string]string{LabelKey: DefaultLabelValue},
 			)
 		}
 
@@ -81,6 +82,116 @@ func TestReflectorSimple(t *testing.T) {
 
 		if string(secret.Data["bar"]) != "baz" {
 			t.Fatalf("secret value does not equal baz: %s", string(secret.Data["bar"]))
+		}
+	})
+}
+
+func TestReflectorAdditionalSecretLabelsVault(t *testing.T) {
+	allEngineTest(t, func(t testing.TB, engineType vault.EngineType) {
+		ctx := context.Background()
+
+		k8sClient := k8sfake.NewSimpleClientset()
+		vaultClient := vault.NewMock(map[string]vault.EngineType{
+			"secrets": engineType,
+		})
+
+		data := map[string]interface{}{
+			"foo": "bar",
+			"bar": "baz",
+		}
+		vaultClient.Write("secrets/data/foo", data)
+
+		r := NewReflector(
+			vaultClient,
+			gsm.NewMockGSM(nil),
+			k8sClient, DefaultNamespace,
+			DefaultLabelValue,
+		)
+
+		err := r.Reflect(ctx, []Mapping{
+			{
+				SourceType:             "vault",
+				Path:                   "secrets/data/foo",
+				SecretName:             "foo",
+				VaultEngineType:        engineType,
+				AdditionalSecretLabels: map[string]string{"secret": "foo"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work: %s", err)
+		}
+
+		// now get the secret out of k8s
+		secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+		secret, err := secrets.Get(ctx, "foo", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("secret should be there: %s", err)
+		}
+
+		// check additional labels and default
+		if !maps.Equal(secret.Labels, map[string]string{LabelKey: DefaultLabelValue, "secret": "foo"}) {
+			t.Fatalf("labels do not match: got %v, want %v", secret.Labels,
+				map[string]string{LabelKey: DefaultLabelValue, "secret": "foo"},
+			)
+		}
+
+		if string(secret.Data["foo"]) != "bar" {
+			t.Fatalf("secret value does not equal bar: %s", string(secret.Data["foo"]))
+		}
+
+		if string(secret.Data["bar"]) != "baz" {
+			t.Fatalf("secret value does not equal baz: %s", string(secret.Data["bar"]))
+		}
+	})
+}
+
+func TestReflectorDefaultLabelOverwriteVault(t *testing.T) {
+	allEngineTest(t, func(t testing.TB, engineType vault.EngineType) {
+		ctx := context.Background()
+
+		k8sClient := k8sfake.NewSimpleClientset()
+		vaultClient := vault.NewMock(map[string]vault.EngineType{
+			"secrets": engineType,
+		})
+
+		data := map[string]interface{}{
+			"foo": "bar",
+			"bar": "baz",
+		}
+		vaultClient.Write("secrets/data/foo", data)
+
+		r := NewReflector(
+			vaultClient,
+			gsm.NewMockGSM(nil),
+			k8sClient, DefaultNamespace,
+			DefaultLabelValue,
+		)
+
+		err := r.Reflect(ctx, []Mapping{
+			{
+				SourceType:             "vault",
+				Path:                   "secrets/data/foo",
+				SecretName:             "foo",
+				VaultEngineType:        engineType,
+				AdditionalSecretLabels: map[string]string{LabelKey: "wrong-value"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("reflect didn't work: %s", err)
+		}
+
+		// now get the secret out of k8s
+		secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+		secret, err := secrets.Get(ctx, "foo", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("secret should be there: %s", err)
+		}
+
+		// ensure default `pentagon` label was not overwritten
+		if string(secret.Labels[LabelKey]) != DefaultLabelValue {
+			t.Fatalf("default pentagon label should be %s is %s", DefaultLabelValue, secret.Labels[LabelKey])
 		}
 	})
 }
@@ -120,16 +231,110 @@ func TestReflectorGSM(t *testing.T) {
 		t.Fatalf("secret should be there: %s", err)
 	}
 
-	if secret.Labels[LabelKey] != DefaultLabelValue {
-		t.Fatalf(
-			"secret pentagon label should be %s is %s",
-			DefaultLabelValue,
-			secret.Labels[LabelKey],
+	// no additional labels provided. check for default
+	if !maps.Equal(secret.Labels, map[string]string{LabelKey: DefaultLabelValue}) {
+		t.Fatalf("labels do not match: got %v, want %v", secret.Labels,
+			map[string]string{LabelKey: DefaultLabelValue},
 		)
 	}
 
 	if string(secret.Data["foo-key"]) != "foo_bar_latest" {
 		t.Fatalf("secret value does not equal foo_bar_latest: %s", string(secret.Data["foo"]))
+	}
+}
+
+func TestReflectorAdditionalSecretLabelsGSM(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := k8sfake.NewSimpleClientset()
+
+	gsm := gsm.NewMockGSM(map[string][]byte{
+		"projects/foo/secrets/bar/versions/latest": []byte("foo_bar_latest"),
+	})
+
+	r := NewReflector(
+		nil,
+		gsm,
+		k8sClient, DefaultNamespace,
+		DefaultLabelValue,
+	)
+
+	err := r.Reflect(ctx, []Mapping{
+		{
+			SourceType:             "gsm",
+			Path:                   "projects/foo/secrets/bar/versions/latest",
+			SecretName:             "foo",
+			GSMSecretKeyValue:      "foo-key",
+			AdditionalSecretLabels: map[string]string{"secret": "foo"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("reflect didn't work: %s", err)
+	}
+
+	// now get the secret out of k8s
+	secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+	secret, err := secrets.Get(ctx, "foo", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("secret should be there: %s", err)
+	}
+
+	// check additional labels and default
+	if !maps.Equal(secret.Labels, map[string]string{LabelKey: DefaultLabelValue, "secret": "foo"}) {
+		t.Fatalf("labels do not match: got %v, want %v", secret.Labels,
+			map[string]string{LabelKey: DefaultLabelValue, "secret": "foo"},
+		)
+	}
+
+	// ensure default `pentagon` label was no overwritten
+	if string(secret.Labels[LabelKey]) != DefaultLabelValue {
+		t.Fatalf("default pentagon label should be %s is %s", DefaultLabelValue, secret.Labels[LabelKey])
+	}
+
+	if string(secret.Data["foo-key"]) != "foo_bar_latest" {
+		t.Fatalf("secret value does not equal foo_bar_latest: %s", string(secret.Data["foo"]))
+	}
+}
+
+func TestReflectorDefaultLabelOverwriteGSM(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := k8sfake.NewSimpleClientset()
+
+	gsm := gsm.NewMockGSM(map[string][]byte{
+		"projects/foo/secrets/bar/versions/latest": []byte("foo_bar_latest"),
+	})
+
+	r := NewReflector(
+		nil,
+		gsm,
+		k8sClient, DefaultNamespace,
+		DefaultLabelValue,
+	)
+
+	err := r.Reflect(ctx, []Mapping{
+		{
+			SourceType:             "gsm",
+			Path:                   "projects/foo/secrets/bar/versions/latest",
+			SecretName:             "foo",
+			GSMSecretKeyValue:      "foo-key",
+			AdditionalSecretLabels: map[string]string{LabelKey: "wrong-value"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("reflect didn't work: %s", err)
+	}
+
+	// now get the secret out of k8s
+	secrets := k8sClient.CoreV1().Secrets(DefaultNamespace)
+
+	secret, err := secrets.Get(ctx, "foo", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("secret should be there: %s", err)
+	}
+
+	// ensure default `pentagon` label was not overwritten
+	if string(secret.Labels[LabelKey]) != DefaultLabelValue {
+		t.Fatalf("default pentagon label should be %s is %s", DefaultLabelValue, secret.Labels[LabelKey])
 	}
 }
 


### PR DESCRIPTION
This pull requests extends Pentagon's secret mapping config to allow for extra labels to be added to the generated Kubernetes secret(s).

additionalSecretLabels can optionally be added to a mapping config. additionalSecretLabels will be merged with the top level default label config value.

Extended existing test cases to account for scenarios where no additional labels have been provided, ensuring the default label still exists. Introduced new test cases where additional labels are provided, ensuring the default label still exists.

Duplicates https://github.com/vimeo/pentagon/pull/31 without forking the reop