### PR TITLE
Create the Google Secret Manager client only when a mapping uses GSM

### DIFF
--- a/pentagon/main.go
+++ b/pentagon/main.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/vimeo/pentagon"
+	"github.com/vimeo/pentagon/gsm"
 	"github.com/vimeo/pentagon/vault"
 )
 
@@ -76,7 +77,7 @@ func main() {
 		os.Exit(31)
 	}
 
-	var gsmClient *secretmanager.Client
+	var gsmClient gsm.SecretAccessor
 	needGSM := false
 	for _, m := range config.Mappings {
 		if m.SourceType == pentagon.GSMSourceType {
@@ -85,12 +86,13 @@ func main() {
 		}
 	}
 	if needGSM {
-		gsmClient, err = secretmanager.NewClient(ctx)
-		if err != nil {
-			log.Printf("unable to get GSM client: %s", err)
+		client, gsmErr := secretmanager.NewClient(ctx)
+		if gsmErr != nil {
+			log.Printf("unable to get GSM client: %s", gsmErr)
 			os.Exit(32)
 		}
-		defer gsmClient.Close()
+		defer client.Close()
+		gsmClient = client
 	}
 
 	reflector := pentagon.NewReflector(

--- a/pentagon/main.go
+++ b/pentagon/main.go
@@ -76,12 +76,22 @@ func main() {
 		os.Exit(31)
 	}
 
-	gsmClient, err := secretmanager.NewClient(ctx)
-	if err != nil {
-		log.Printf("unable to get GSM client: %s", err)
-		os.Exit(32)
+	var gsmClient *secretmanager.Client
+	needGSM := false
+	for _, m := range config.Mappings {
+		if m.SourceType == pentagon.GSMSourceType {
+			needGSM = true
+			break
+		}
 	}
-	defer gsmClient.Close()
+	if needGSM {
+		gsmClient, err = secretmanager.NewClient(ctx)
+		if err != nil {
+			log.Printf("unable to get GSM client: %s", err)
+			os.Exit(32)
+		}
+		defer gsmClient.Close()
+	}
 
 	reflector := pentagon.NewReflector(
 		vaultClient.Logical(),


### PR DESCRIPTION
### Problem

`main()` builds a Google Secret Manager client unconditionally at startup (`secretmanager.NewClient(ctx)`), regardless of whether any mapping sources from GSM. The Google SDK resolves Application Default Credentials eagerly at construction, so GCP credentials become a hard startup requirement for *every* deployment — including pure-Vault ones that never touch GSM.

On a non-GCP cluster (e.g. Vault-only reflection on-prem) pentagon dies at startup with:

  unable to get GSM client: credentials: could not find default credentials

  (exit code 32), even though the GSM client is never used.

### Fix

Build the GSM client lazily: only call `secretmanager.NewClient` when at least one mapping has `SourceType == GSMSourceType`. When no mapping uses GSM the client stays `nil` and is never dereferenced — `Reflector.getGSMSecret` is only reached for GSM-sourced mappings — so Vault-only deployments no longer need any GCP credential.

### Behaviour

- Vault-only config, no GCP credentials: starts normally (previously exit 32).
- Config with a `gsm` mapping: unchanged — a missing/invalid credential still fails fast at startup.

### Testing

- `go test ./...` passes.
- Verified manually: a Vault-only config now reaches the reflection step with no GCP credentials present; a config with a `gsm` mapping still requires the GSM client.
